### PR TITLE
Add key-press to openssl call

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,7 +25,7 @@
   when: ansible_distribution == "Ubuntu"
   
 - name: make temp ssl file
-  shell: openssl s_client -host {{ ldap_uri }} -port 636 -showcerts > /tmp/{{ ldap_uri }}.pem
+  shell: echo 'q' | openssl s_client -host {{ ldap_uri }} -port 636 -showcerts > /tmp/{{ ldap_uri }}.pem
   changed_when: False
 
 - name: ssl cert copied


### PR DESCRIPTION
The `openssl` call currently does not return control to the shell unless it receives a key-press. Adding an `echo` statement solves this problem.